### PR TITLE
Update JPAUnitTestCase.java

### DIFF
--- a/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
+++ b/src/test/java/org/hibernate/bugs/JPAUnitTestCase.java
@@ -40,6 +40,7 @@ public class JPAUnitTestCase {
 		entityManager.getTransaction().begin();
 
 		MyFieldEntity myFieldEntity = new MyFieldEntity();
+		// This direct access on the field bypasses the bytecode enhancement logic and causes the test to fail
 		myFieldEntity.id = "myid";
 		entityManager.persist(myFieldEntity);
 
@@ -50,7 +51,8 @@ public class JPAUnitTestCase {
 		entityManager.getTransaction().commit();
 
 		entityManager.getTransaction().begin();
-
+		
+		// Same in this case: the bytecode enhacement logic is not triggered by this direc access to the field
 		myFieldEntity.myfield = "myfieldvalue";
 		myMethodEntity.setMyfield("mymethodvalue");
 


### PR DESCRIPTION
There are 2 ways to make this test pass:

1 - [recomended] add a getter/setter to the entity

2 - enable ''extended enhancement" on the build plugin

By default, bytecode manipulation is restricted to classes that are entities. That is to keep the number of modified classes to the minimum. This requires that all the fields for the persistent attributes to be manipulated only in the entity itself (which is the right way to program under the OO paradigm). 

There are cases where the code can't be modified and for those scenarios there is 'extended enhancement' that convert the field access to the right method call. It's used throughout the test suite to reduce the boilerplate, so it's tested and works well, but it's not recommended because of the reasons mentioned.

I hope this helps you solve your problem and I'm happy to help with anything related to bytecode enhacement!